### PR TITLE
Removed set-based tagging

### DIFF
--- a/src/import-bg.rb
+++ b/src/import-bg.rb
@@ -7,6 +7,7 @@ require "addressable"
 scale = 0.8
 rotation = 180
 rowsize = 16
+tag="background"
 
 # Each char folder is a set, e.g. greenhouse-wench
 Dir.mkdir(BG_SAVED_DIR) unless File.exists?(BG_SAVED_DIR)
@@ -29,7 +30,7 @@ sets.each do |set|
       url:url,
       posZ:posZ,
       posX:posX,
-      tag:set,
+      tag:tag,
       scale:scale,
       rotation:rotation
       }

--- a/src/import-char.rb
+++ b/src/import-char.rb
@@ -8,6 +8,7 @@ scale = 0.7
 rowsize = 16
 imgscale = 2
 rotation = 0
+tag = "character"
 
 # Each char folder is a set, e.g. greenhouse-wench
 Dir.mkdir(CHAR_SAVED_DIR) unless File.exists?(CHAR_SAVED_DIR)
@@ -31,7 +32,7 @@ sets.each do |set|
       posZ:posZ,
       posX:posX,
       scale:scale,
-      tag:set,
+      tag:tag,
       imgscale:imgscale,
       rotation:rotation
       }

--- a/src/import-map.rb
+++ b/src/import-map.rb
@@ -5,6 +5,7 @@ mapwidth = 50
 mapheight = 50
 scale = 0.99
 text = "%99"
+tag = "tile"
 
 class String
   def init
@@ -89,7 +90,7 @@ maps.each do |map|
                 name:name,
                 desc:desc,
                 notes:notes,
-                tag:name,
+                tag:tag,
                 hex:hex,
                 backurl:backurl,
                 text:text

--- a/src/templates.rb
+++ b/src/templates.rb
@@ -46,7 +46,7 @@ CHAR_ENTRY = "
   \"b\": 1
 },
 \"Tags\": [
-  \"char\",\"%{tag}\"
+  \"%{tag}\"
 ],
 },"
 CHAR_CLOSE = "]}"
@@ -90,7 +90,7 @@ ITEM_ENTRY = "{
   \"b\": 0.713235259
 },
 \"Tags\": [
-  \"item\",\"%{tag}\"
+  \"%{tag}\"
 ],
 \"CardID\": %{cardnum}00,
 \"SidewaysCard\": false,
@@ -154,7 +154,7 @@ MAP_ENTRY = "
 }
 },
 \"Tags\": [
-  \"map-tile\",\"%{tag}\"
+  \"%{tag}\"
 ],
 \"LuaScript\": \"\",
 \"LuaScriptState\": \"\",
@@ -192,7 +192,7 @@ BG_ENTRY = "    {
 \"ImageURL\": \"%{url}\",
 },
 \"Tags\": [
-  \"bg\",\"%{tag}\"
+  \"%{tag}\"
 ],
 },"
 BG_CLOSE = "]}"
@@ -226,7 +226,7 @@ STATED_ENTRY_FIRST = "{
 \"ImageURL\": \"%{url}\",
 },
 \"Tags\": [
-  \"stated-token\",\"%{tag}\"
+  \"%{tag}\"
 ],
 \"LuaScript\": \"\",
 \"LuaScriptState\": \"\",


### PR DESCRIPTION
Tagging each char/item/bg with their set can be re-implemented when there's a reason for it, as it stands there are far too many tags being created for the tag menu in-game to be navigable