### PR TITLE
Stored printed mixup

### DIFF
--- a/src/card/storage_adapters/git_storage_adapter.rb
+++ b/src/card/storage_adapters/git_storage_adapter.rb
@@ -49,7 +49,7 @@ module Card
         update_manifest
       end
 
-      def printed_cards
+      def stored_cards
         @stored_cards.values
       end
 

--- a/src/import-cards.rb
+++ b/src/import-cards.rb
@@ -14,8 +14,8 @@ individual_card_importer = TabletopSimulator::Importers::IndividualCardImporter.
 
 storage_adapter = Card::StorageAdapters::GitStorageAdapter.new
 
-printed_cards = storage_adapter.printed_cards
+stored_cards = storage_adapter.stored_cards
 
-printed_cards.each do |printed_card|
-  individual_card_importer.import(printed_card)
+stored_cards.each do |stored_card|
+  individual_card_importer.import(stored_card)
 end

--- a/src/tabletop_simulator/card_format_translator.rb
+++ b/src/tabletop_simulator/card_format_translator.rb
@@ -7,19 +7,19 @@ module TabletopSimulator
     BASE_CARD_ID = 100
     CARD_ID_INCREMENT = 100
 
-    def translate_card(printed_card, card_id=nil)
+    def translate_card(stored_card, card_id=nil)
       TabletopSimulator::Models::ObjectState.card(
-        nickname: printed_card.spec.title,
-        front_url: printed_card.image_url,
-        back_url: "http://cloud-3.steamusercontent.com/ugc/1770453729835188440/BA89FF48561CCA952BFB77A6C9891E0C38DB3559/",
+        nickname: stored_card.spec.title,
+        front_url: stored_card.image_url,
+        back_url: stored_card.back_url,
         card_id: card_id
       )
     end
 
-    def translate_cards(printed_cards)
+    def translate_cards(stored_cards)
       card_id = BASE_CARD_ID
 
-      printed_cards.map do |card|
+      stored_cards.map do |card|
         translated_card = translate_card(card, card_id)
 
         card_id += CARD_ID_INCREMENT

--- a/src/tabletop_simulator/importers/individual_card_importer.rb
+++ b/src/tabletop_simulator/importers/individual_card_importer.rb
@@ -14,10 +14,10 @@ module TabletopSimulator
         @base_directory = base_directory
       end
 
-      def import(printed_card)
-        card = TabletopSimulator::Models::Object.new(translate_card(printed_card))
+      def import(stored_card)
+        card = TabletopSimulator::Models::Object.new(translate_card(stored_card))
 
-        save_individual_card(card, printed_card.spec.title)
+        save_individual_card(card, stored_card.spec.title)
       end
 
       private


### PR DESCRIPTION
There was a mixup between `PrintedCards` and `StoredCards` which was causing confusion and resulted in the card back bug.

`PrintedCards` are an object representing a generated asset, including an image file and the specification used to generate it.

`StoredCards` are an object representing a card that's stored online, including links to the front and back images of the card along with the specification of the card.

In the storage adapter, I mistakenly called the method to retrieve the print manifest `printed_cards`, which misled me into using `printed_cards` as the variable name everywhere downstream and forgetting that they were actually `StoredCards`. The naming should be all straightened out now.